### PR TITLE
Add claim info to project detail API

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -569,6 +569,9 @@ const docTemplate = `{
                 "end_time": {
                     "type": "string"
                 },
+                "has_received": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -579,6 +582,9 @@ const docTemplate = `{
                     "$ref": "#/definitions/oauth.TrustLevel"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "received_content": {
                     "type": "string"
                 },
                 "risk_level": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -560,6 +560,9 @@
                 "end_time": {
                     "type": "string"
                 },
+                "has_received": {
+                    "type": "boolean"
+                },
                 "id": {
                     "type": "string"
                 },
@@ -570,6 +573,9 @@
                     "$ref": "#/definitions/oauth.TrustLevel"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "received_content": {
                     "type": "string"
                 },
                 "risk_level": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -142,6 +142,8 @@ definitions:
         $ref: '#/definitions/project.DistributionType'
       end_time:
         type: string
+      has_received:
+        type: boolean
       id:
         type: string
       is_completed:
@@ -149,6 +151,8 @@ definitions:
       minimum_trust_level:
         $ref: '#/definitions/oauth.TrustLevel'
       name:
+        type: string
+      received_content:
         type: string
       risk_level:
         type: integer

--- a/frontend/components/common/receive/ReceiveMain.tsx
+++ b/frontend/components/common/receive/ReceiveMain.tsx
@@ -247,6 +247,8 @@ export function ReceiveMain() {
 
       if (result.success && result.data) {
         setProject(result.data);
+        setHasReceived(result.data.has_received);
+        setReceivedContent(result.data.received_content);
       } else {
         setError(result.error || '获取项目详情失败');
       }
@@ -273,10 +275,7 @@ export function ReceiveMain() {
           ...prev,
           available_items_count: prev.available_items_count - 1,
         } : null);
-
-        const content = '您的兑换码';
-        setHasReceived(true);
-        setReceivedContent(content);
+        await fetchProject();
         toast.success('领取成功！');
       } else {
         toast.error(result.error || '领取失败');

--- a/frontend/lib/services/project/types.ts
+++ b/frontend/lib/services/project/types.ts
@@ -1,4 +1,4 @@
-import {TrustLevel} from '../core/types';
+import { TrustLevel } from "../core/types";
 
 /**
  * 项目分发类型
@@ -183,6 +183,10 @@ export interface GetProjectResponseData extends Project {
   tags: string[] | null;
   /** 可领取数量 */
   available_items_count: number;
+  /** 是否已经领取 */
+  has_received: boolean;
+  /** 领取内容 */
+  received_content: string | null;
 }
 
 /**

--- a/internal/apps/project/routers.go
+++ b/internal/apps/project/routers.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/linux-do/cdk/internal/apps/oauth"
@@ -31,6 +32,8 @@ type GetProjectResponseData struct {
 	CreatorNickname     string           `json:"creator_nickname"`
 	Tags                []string         `json:"tags"`
 	AvailableItemsCount int64            `json:"available_items_count"`
+	HasReceived         bool             `json:"has_received"`
+	ReceivedContent     string           `json:"received_content"`
 }
 
 // GetProject
@@ -64,12 +67,29 @@ func GetProject(c *gin.Context) {
 	}
 	availableItemsCount := stock
 
+	var item ProjectItem
+	hasReceived := false
+	receivedContent := ""
+	if err := db.DB(c.Request.Context()).
+		Where("project_id = ? AND receiver_id = ?", projectID, oauth.GetUserIDFromContext(c)).
+		First(&item).Error; err != nil {
+		if !errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusInternalServerError, ProjectResponse{ErrorMsg: err.Error()})
+			return
+		}
+	} else {
+		hasReceived = true
+		receivedContent = item.Content
+	}
+
 	responseData := GetProjectResponseData{
 		Project:             project,
 		CreatorUsername:     project.Creator.Username,
 		CreatorNickname:     project.Creator.Nickname,
 		Tags:                tags,
 		AvailableItemsCount: availableItemsCount,
+		HasReceived:         hasReceived,
+		ReceivedContent:     receivedContent,
 	}
 
 	c.JSON(http.StatusOK, ProjectResponse{Data: responseData})


### PR DESCRIPTION
## Summary
- include receive status and content in project detail response
- expose new fields on frontend types
- display received info in receive page
- update API docs

## Testing
- `go build ./...`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684be54cd20c832c9702007705bf83a0