### PR TITLE
Add claim info for project API

### DIFF
--- a/internal/apps/project/models.go
+++ b/internal/apps/project/models.go
@@ -191,3 +191,11 @@ func (p *ProjectItem) Exact(tx *gorm.DB, id uint64) error {
 	}
 	return nil
 }
+
+func (p *Project) GetReceivedItem(ctx context.Context, userID uint64) (*ProjectItem, error) {
+	item := &ProjectItem{}
+	if err := db.DB(ctx).Where("project_id = ? AND receiver_id = ?", p.ID, userID).First(item).Error; err != nil {
+		return nil, err
+	}
+	return item, nil
+}


### PR DESCRIPTION
## Summary
- add method to fetch received item for a project
- return claim status and content in get project API

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_b_684be8926b60832c8967a7753c542286